### PR TITLE
Added static-content (API Docs + IM Console)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ The following table lists the configurable parameters of the integration-manager
 | `jobScheduler.nodeSelector` | set nodeSelector | {} |
 | `jobScheduler.service.annotations` | service annotations | {} |
 | `jobScheduler.service.type` | service type | ClusterIP |
+| `staticContent.image` | image to pull for integration manager's static content (apidocs, console) | actian/integration-manager-static-content:2.0.5.270 |
+| `staticContent.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
+| `staticContent.affinity` | node/pod affinities | {} |
+| `staticContent.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 10, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/", "port": 80 }} |
+| `staticContent.readinessProbe` | pod readiness probe | { "initialDelaySeconds": 5, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/", "port": 80 }} |
+| `staticContent.pullPolicy` | when to pull image | IfNotPresent
+| `staticContent.extraInitContainers` | init containers for pod | [] |
+| `staticContent.pdb` | pod disruption budget | {} |
+| `staticContent.replicaCount` | number of pods to run | 1 |
+| `staticContent.extraLabels` | additional labels to add | {} |
+| `staticContent.podAnnotations` | pod annotations | {} |
+| `staticContent.resources` | set resource limits | {} |
+| `staticContent.nodeSelector` | set nodeSelector | {} |
+| `staticContent.service.annotations` | service annotations | {} |
+| `staticContent.baseEndpoint` | integration manager base endpoint for the browser to send requests to | nil |
+| `staticContent.jobsEndpoint` | job execution endpoint for the browser to send requests to | nil |
+| `staticContent.salesForceLoginUrl` | salesforce url for login redirect | nil |
+| `staticContent.agentInstallerUrlWindows` | location for the windows agent installer | nil |
+| `staticContent.agentInstallerUrlLinux` | location for the linux agent installer | nil |
 | `prometheus.operator.enabled` | creates service monitors when true | false |
 | `prometheus.operator.serviceMonitor.interval` | interval for prometheus scraping | 10s |
 | `ingress.enabled` | create ingress resource | true |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following table lists the configurable parameters of the integration-manager
 | -----  | ----- | ------|
 | `imagePullSecrets` | name of Secret resource containing private registry credentials | [] |
 | `extraConfig` | additional properties to include in the config map | {} |
-| `aggregator.image` | image to pull for the aggregator service | actian/aggregator-service:2.0.5.270 |
+| `aggregator.image` | image to pull for the aggregator service | actian/aggregator-service:2.0.6.294 |
 | `aggregator.config` | configuration enabling aggregation for specific job configurations | [] |
 | `aggregator.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `aggregator.affinity` | node/pod affinities | {} |
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the integration-manager
 | `aggregator.nodeSelector` | set nodeSelector | {} |
 | `aggregator.service.annotations` | service annotations | {} |
 | `aggregator.service.type` | service type | ClusterIP |
-| `aggregatorProcessor.image` | image to pull for the aggregator processor | actian/aggregator-processor:2.0.5.270 |
+| `aggregatorProcessor.image` | image to pull for the aggregator processor | actian/aggregator-processor:2.0.6.294 |
 | `aggregatorProcessor.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `aggregatorProcessor.affinity` | node/pod affinities | {} |
 | `aggregatorProcessor.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 120, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/health", "port": 8080 }} |
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the integration-manager
 | `aggregatorProcessor.podAnnotations` | pod annotations | {} |
 | `aggregatorProcessor.resources` | set resource limits | {} |
 | `aggregatorProcessor.nodeSelector` | set nodeSelector | {} |
-| `integrationManagerBase.image` | image to pull for the integration manager base service | actian/integration-manager-base:2.0.5.270 |
+| `integrationManagerBase.image` | image to pull for the integration manager base service | actian/integration-manager-base:2.0.6.294 |
 | `integrationManagerBase.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `integrationManagerBase.affinity` | node/pod affinities | {} |
 | `integrationManagerBase.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 120, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/health", "port": 8080 }} |
@@ -70,7 +70,7 @@ The following table lists the configurable parameters of the integration-manager
 | `integrationManagerBase.nodeSelector` | set nodeSelector | {} |
 | `integrationManagerBase.service.annotations` | service annotations | {} |
 | `integrationManagerBase.service.type` | service type | ClusterIP |
-| `jobExecution.image` | image to pull for the job execution service | actian/job-execution-service:2.0.5.270 |
+| `jobExecution.image` | image to pull for the job execution service | actian/job-execution-service:2.0.6.294 |
 | `jobExecution.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `jobExecution.affinity` | node/pod affinities | {} |
 | `jobExecution.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 120, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/health", "port": 8080 }} |
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the integration-manager
 | `jobExecution.nodeSelector` | set nodeSelector | {} |
 | `jobExecution.service.annotations` | service annotations | {} |
 | `jobExecution.service.type` | service type | ClusterIP |
-| `jobResultsProcessor.image` | image to pull for the job results processor service | actian/job-results-processor:2.0.5.270 |
+| `jobResultsProcessor.image` | image to pull for the job results processor service | actian/job-results-processor:2.0.6.294 |
 | `jobResultsProcessor.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `jobResultsProcessor.affinity` | node/pod affinities | {} |
 | `jobResultsProcessor.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 120, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/health", "port": 8080 }} |
@@ -102,7 +102,7 @@ The following table lists the configurable parameters of the integration-manager
 | `jobResultsProcessor.nodeSelector` | set nodeSelector | {} |
 | `jobResultsProcessor.service.annotations` | service annotations | {} |
 | `jobResultsProcessor.service.type` | service type | ClusterIP |
-| `jobScheduler.image` | image to pull for the job scheduler service | actian/job-scheduler-service:2.0.5.270 |
+| `jobScheduler.image` | image to pull for the job scheduler service | actian/job-scheduler-service:2.0.6.294 |
 | `jobScheduler.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `jobScheduler.affinity` | node/pod affinities | {} |
 | `jobScheduler.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 120, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/health", "port": 8080 }} |
@@ -118,7 +118,7 @@ The following table lists the configurable parameters of the integration-manager
 | `jobScheduler.nodeSelector` | set nodeSelector | {} |
 | `jobScheduler.service.annotations` | service annotations | {} |
 | `jobScheduler.service.type` | service type | ClusterIP |
-| `staticContent.image` | image to pull for integration manager's static content (apidocs, console) | actian/integration-manager-static-content:2.0.5.270 |
+| `staticContent.image` | image to pull for integration manager's static content (apidocs, console) | actian/integration-manager-static-content:2.0.6.294 |
 | `staticContent.revisionHistoryLimit` | the number of old history to retain to allow rollback | 10 |
 | `staticContent.affinity` | node/pod affinities | {} |
 | `staticContent.livenessProbe` | pod liveness probe | { "initialDelaySeconds": 10, "periodSeconds": 10, "timeoutSeconds": 5, "successThreshhold": 1, "failureThreshhold": 3, "httpGet": { "scheme": "HTTP", "path": "/", "port": 80 }} |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -55,3 +55,8 @@ so truncation should be 63-22=41.
 {{- define "integration-manager.job-scheduler.fullname" -}}
 {{- printf "%s-job-scheduler" (include "integration-manager.fullname" .) -}}
 {{- end }}
+
+{{/* Fullname suffixed with static-content */}}
+{{- define "integration-manager.static-content.fullname" -}}
+{{- printf "%s-static-content" (include "integration-manager.fullname" .) -}}
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -189,8 +189,8 @@ spec:
           path: /.well-known/openid-configuration
           {{- end }}
         - backend:
-            serviceName: {{ template "integration-manager.base.fullname" . }}
-            servicePort: 8080
+            serviceName: {{ template "integration-manager.static-content.fullname" . }}
+            servicePort: 80
           {{- if .Values.ingress.pathVersionPrefix }}
           path: /{{ .Values.ingress.pathVersionPrefix }}/(apidocs.*)
           {{- else }}
@@ -198,9 +198,23 @@ spec:
           {{- end }}
         {{- if .Values.ingress.pathVersionPrefix }}
         - backend:
-            serviceName: {{ template "integration-manager.base.fullname" . }}
-            servicePort: 8080
+            serviceName: {{ template "integration-manager.static-content.fullname" . }}
+            servicePort: 80
           path: /(apidocs.*)
+        {{- end }}
+        - backend:
+            serviceName: {{ template "integration-manager.static-content.fullname" . }}
+            servicePort: 80
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(ui.*)
+          {{- else }}
+          path: /ui
+          {{- end }}
+        {{- if .Values.ingress.pathVersionPrefix }}
+        - backend:
+            serviceName: {{ template "integration-manager.static-content.fullname" . }}
+            servicePort: 80
+          path: /(ui.*)
         {{- end }}
         - backend:
             serviceName: {{ template "integration-manager.job-scheduler.fullname" . }}

--- a/templates/static-content-configmap.yaml
+++ b/templates/static-content-configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "integration-manager.static-content.fullname" . }}
+  labels:
+    app: integration-manager
+    chart: {{ template "integration-manager.chart" . }}
+    release: {{ .Release.Name }}
+data:
+  appConfig.json: |
+    {
+      "isCloud": true,
+
+      "agentInstallerUrl": "",
+      "agentInstallerUrlWindows": "{{ .Values.staticContent.agentInstallerUrlWindows }}",
+      "agentInstallerUrlLinux": "{{ .Values.staticContent.agentInstallerUrlLinux }}",
+      "resetCloudUserPwdUrl": "",
+      "siteStatusUrl": "",
+      "salesForceLoginUrl": "{{ .Values.staticContent.salesForceLoginUrl }}",
+
+      "BASE_URL_ACL": "",
+      "BASE_URL_ACL_ENTITY": "",
+      "BASE_URL_LOGIN": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_JOB_CONFIGS": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_JOBS": "{{ .Values.staticContent.jobsEndpoint }}/api",
+      "BASE_URL_MACROSET": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_PACKAGES": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_ACCOUNT_MANAGER": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_AGENTS": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_GROUPS_MANAGER": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_LICENSE": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_SUBSCRIPTION": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_MACRO": "{{ .Values.staticContent.baseEndpoint }}/api",
+      "BASE_URL_DESTINATION": "{{ .Values.staticContent.baseEndpoint }}/
+    }
+

--- a/templates/static-content-deployment.yaml
+++ b/templates/static-content-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "integration-manager.static-content.fullname" . }}
+  labels:
+    app: integration-manager
+    component: static-content
+    chart: {{ template "integration-manager.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.staticContent.replicaCount }}
+  revisionHistoryLimit: {{ .Values.staticContent.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: integration-manager
+      component: static-content
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/staticcontentconfig: {{ include (print $.Template.BasePath "/static-content-configmap.yaml") . | sha256sum }}
+        {{- if .Values.staticContent.podAnnotations }}
+        {{ .Values.staticContent.podAnnotations | toYaml | indent 8 | trim }}
+        {{- end }}
+      labels:
+        app: integration-manager
+        component: static-content
+        chart: {{ template "integration-manager.chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.staticContent.extraLabels }}
+        {{ .Values.staticContent.extraLabels | toYaml | indent 8 | trim }}
+        {{- end }}
+    spec:
+      {{- if .Values.staticContent.affinity }}
+      affinity:
+        {{ .Values.staticContent.affinity | toYaml | indent 8 | trim }}
+      {{- end }}
+      serviceAccountName: {{ template "integration-manager.fullname" . }}
+      {{- if .Values.staticContent.nodeSelector }}
+      nodeSelector:
+        {{ .Values.staticContent.nodeSelector | toYaml | indent 8 | trim }}
+      {{- end }}
+      {{- if .Values.staticContent.extraInitContainers }}
+      initContainers:
+        {{ tpl .Values.staticContent.extraInitContainers . | indent 6 | trim }}
+      {{- end }}
+      containers:
+      - name: static-content
+        image: {{ .Values.staticContent.image }}
+        imagePullPolicy: {{ .Values.staticContent.pullPolicy }}
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: app-config
+          readOnly: true
+          mountPath: /opt/Actian/volume
+        readinessProbe:
+          {{ .Values.staticContent.readinessProbe | toYaml | indent 10 | trim }}
+        livenessProbe:
+          {{ .Values.staticContent.livenessProbe | toYaml | indent 10 | trim }}
+        {{- if .Values.staticContent.resources }}
+        resources:
+          {{ .Values.staticContent.resources | toYaml | indent 10 | trim }}
+        {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      volumes:
+      - name: app-config
+        configMap:
+          name: {{ template "integration-manager.static-content.fullname" . }}

--- a/templates/static-content-pdb.yaml
+++ b/templates/static-content-pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.staticContent.pdb }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "integration-manager.static-content.fullname" . }}
+  labels:
+    app: integration-manager
+    component: static-content
+    chart: {{ template "integration-manager.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: integration-manager
+      component: static-content
+      release: {{ .Release.Name }}
+  {{ toYaml .Values.staticContent.pdb | indent 2 | trim }}
+{{- end }}

--- a/templates/static-content-service.yaml
+++ b/templates/static-content-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "integration-manager.static-content.fullname" . }}
+  {{- if .Values.staticContent.service.annotations }}
+  annotations:
+    {{ .Values.staticContent.service.annotations  | toYaml | indent 4 | trim }}
+  {{- end }}
+  labels:
+    app: integration-manager
+    component: static-content
+    chart: {{ template "integration-manager.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: integration-manager
+    component: static-content
+    release: {{ .Release.Name }}
+  type: "{{ .Values.staticContent.service.type }}"

--- a/values.yaml
+++ b/values.yaml
@@ -255,7 +255,51 @@ jobScheduler:
   service:
     annotations: {}
     type: ClusterIP
-
+staticContent:
+  image: actian/integration-manager-static-content:2.0.5.270
+  revisionHistoryLimit: 10
+  pdb: {}
+  #minAvailable: 1
+  affinity: {}
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    httpGet:
+      scheme: HTTP
+      path: /
+      port: 80
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    httpGet:
+      scheme: HTTP
+      path: /
+      port: 80
+  pullPolicy: IfNotPresent
+  extraInitContainers: []
+  replicaCount: 1
+  extraLabels: {}
+  podAnnotations: {}
+  resources: {}
+  nodeSelector: {}
+  service:
+    annotations: {}
+    type: ClusterIP
+  # External endpoint for integration-manager-base
+  baseEndpoint:
+  # External endpoint for integration-manager-job-execution
+  jobsEndpoint:
+  # Salesforce endpoint to redirect login
+  salesForceLoginUrl:
+  # Agent installer location - windows
+  agentInstallerUrlWindows:
+  # Agent installer location - linux
+  agentInstallerUrlLinux:
 #Prometheus
 prometheus:
   operator:

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ imagePullSecrets: []
 # Extra values to be added to application.properties
 extraConfig: {}
 aggregator:
-  image: actian/aggregator-service:2.0.5.270
+  image: actian/aggregator-service:2.0.6.294
   # Aggregator Configuration List
   config: []
 #  config:
@@ -89,7 +89,7 @@ aggregator:
     annotations: {}
     type: ClusterIP
 aggregatorProcessor:
-  image: actian/aggregator-processor:2.0.5.270
+  image: actian/aggregator-processor:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
     #minAvailable: 1
@@ -112,7 +112,7 @@ aggregatorProcessor:
   resources: {}
   nodeSelector: {}
 integrationManagerBase:
-  image: actian/integration-manager-base:2.0.5.270
+  image: actian/integration-manager-base:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
     #minAvailable: 1
@@ -148,7 +148,7 @@ integrationManagerBase:
     annotations: {}
     type: ClusterIP
 jobExecution:
-  image: actian/job-execution-service:2.0.5.270
+  image: actian/job-execution-service:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
     #minAvailable: 1
@@ -184,7 +184,7 @@ jobExecution:
     annotations: {}
     type: ClusterIP
 jobResultsProcessor:
-  image: actian/job-results-processor:2.0.5.270
+  image: actian/job-results-processor:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
     #minAvailable: 1
@@ -220,7 +220,7 @@ jobResultsProcessor:
     annotations: {}
     type: ClusterIP
 jobScheduler:
-  image: actian/job-scheduler-service:2.0.5.270
+  image: actian/job-scheduler-service:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
     #minAvailable: 1
@@ -256,7 +256,7 @@ jobScheduler:
     annotations: {}
     type: ClusterIP
 staticContent:
-  image: actian/integration-manager-static-content:2.0.5.270
+  image: actian/integration-manager-static-content:2.0.6.294
   revisionHistoryLimit: 10
   pdb: {}
   #minAvailable: 1


### PR DESCRIPTION
Added support for new static-content image that serves the IM UI + API Docs
- configmap for configuring appConfig.json
- service
- deployment for nginx web server running on port 80 serving /ui & /apidocs
- pod disruption budget
- updated readme + values