### PR TITLE
Ip 4327 add queue.host entry to im/rabbitmq secret

### DIFF
--- a/templates/aggregator-deployment.yaml
+++ b/templates/aggregator-deployment.yaml
@@ -131,6 +131,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/aggregator-processor-deployment.yaml
+++ b/templates/aggregator-processor-deployment.yaml
@@ -129,6 +129,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/base-deployment.yaml
+++ b/templates/base-deployment.yaml
@@ -130,6 +130,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/job-execution-deployment.yaml
+++ b/templates/job-execution-deployment.yaml
@@ -131,6 +131,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/job-results-processor-deployment.yaml
+++ b/templates/job-results-processor-deployment.yaml
@@ -123,6 +123,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/job-scheduler-deployment.yaml
+++ b/templates/job-scheduler-deployment.yaml
@@ -102,6 +102,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -10,6 +10,7 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.existingRabbitSecret }}
+  rabbitmq-host: {{ (toString .Values.amqp.host) | b64enc }}
   rabbitmq-username: {{ (toString .Values.amqp.username) | b64enc }}
   rabbitmq-password: {{ (toString .Values.amqp.password) | b64enc }}
   {{- end }}

--- a/templates/shared-configmap.yaml
+++ b/templates/shared-configmap.yaml
@@ -29,9 +29,9 @@ data:
     spring.datasource.hikari.minimum-idle={{ .Values.datasource.minimumIdle }}
 
     #AMQP
-    queue.host={{ default "none" .Values.amqp.host }}
     queue.port={{ .Values.amqp.port }}
-    # This is a hack to map existing secrets, rabbitmq-username & rabbitmq-password, to our custom queue properties
+    # This is a hack to map existing secrets, rabbitmq-host, rabbitmq-username & rabbitmq-password, to our custom queue properties
+    queue.host=${rabbitmq-host}
     queue.username=${rabbitmq-username}
     queue.password=${rabbitmq-password}
     queue.ssl.enabled={{ .Values.amqp.sslEnabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -344,6 +344,7 @@ existingRabbitSecret: ""
 #     spring.datasource.username
 #     spring.datasource.password
 # If existingRabbitSecret is not specified. These properties must be included as well:
+#     rabbitmq-host
 #     rabbitmq-username
 #     rabbitmq-password
 existingSecret: ""

--- a/values.yaml
+++ b/values.yaml
@@ -349,10 +349,10 @@ existingRabbitSecret: ""
 #     rabbitmq-password
 existingSecret: ""
 amqp:
-  # Set host to rabbitmq-rabbitmq-ha.default.svc.cluster.local if using helm rabbitmq-ha
-  host:
   port: 5672
-  # Only set username & password if not using existingRabbitSecret
+  # Only set host, username & password if not using existingRabbitSecret
+  # Set host to rabbitmq-rabbitmq-ha.default.svc.cluster.local if using helm rabbitmq-ha
+  host:  
   username:
   password:
   sslEnabled: false


### PR DESCRIPTION
Adding key rabbitmq-host to amqp-secret-volume secret existingRabbitSecret in all the deployment.yaml files.
Adding rabbitmq-host to queue.host because of adding im/queue.host to secrets.