### PR TITLE
Example configuration override:

### DIFF
--- a/templates/static-content-configmap.yaml
+++ b/templates/static-content-configmap.yaml
@@ -15,3 +15,7 @@ data:
   whitelist.json: |
     {{ .Values.staticContent.ipWhiteList | toString | indent 4 | trim }}
   {{- end }}
+  {{- if .Values.staticContent.nginxConf }}
+  nginx.conf: |
+    {{ .Values.staticContent.nginxConf | toString | indent 4 | trim  }}
+  {{- end }}

--- a/templates/static-content-deployment.yaml
+++ b/templates/static-content-deployment.yaml
@@ -59,6 +59,11 @@ spec:
           readOnly: true
           mountPath: /usr/share/nginx/html/info/
         {{- end }}
+        {{- if .Values.staticContent.nginxConf }}
+        - name: nginx-conf
+          readOnly: true
+          mountPath: /etc/nginx/conf.d/
+        {{- end }}
         readinessProbe:
           {{ .Values.staticContent.readinessProbe | toYaml | indent 10 | trim }}
         livenessProbe:
@@ -84,4 +89,12 @@ spec:
           items:
             - key: whitelist.json
               path: whitelist.json
+      {{ end }}
+      {{- if .Values.staticContent.nginxConf }}
+      - name: nginx-conf
+        configMap:
+          name: {{ template "integration-manager.static-content.fullname" . }}
+          items:
+            - key: nginx.conf
+              path: default.conf
       {{ end }}


### PR DESCRIPTION
```
  nginxConf: |
    server {

        listen      80;
        root        /usr/share/nginx/html;

        location /apidocs {
            try_files $uri /apidocs/index.html;
        }

        location /ui {
            try_files $uri /dx/index.html;
        }

        location /dx {
            try_files $uri /dx/index.html;
        }

        location /dx/404 {
            try_files $uri /dx/index.html;
        }

        location /im {
            try_files $uri /im/index.html;
        }

        location /awells-custom-path {
            try_files $uri /dx/index.html;
        }
    }
```

If not explicitly overridden, the docker image default nginx.conf will be used