### PR TITLE
fixing resource names for job log streamer

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -46,9 +46,9 @@ so truncation should be 63-22=41.
 {{- printf "%s-job-execution" (include "integration-manager.fullname" .) -}}
 {{- end }}
 
-{{/* Fullname suffixed with job-log-streaming */}}
+{{/* Fullname suffixed with job-log-streamer */}}
 {{- define "integration-manager.job-log-streaming.fullname" -}}
-{{- printf "log-streamer" -}}
+{{- printf "%s-job-log-streamer" (include "integration-manager.fullname" .) -}}
 {{- end }}
 
 {{/* Fullname suffixed with job-results-processor */}}


### PR DESCRIPTION
Current name does not include helm release name

Ex:
```
log-streamer-ff6448c7-wl6xw                                     1/1     Running   0          46h
v2-integration-manager-aggregator-5b96d4c587-tgfsm              1/1     Running   0          46h
v2-integration-manager-aggregator-processor-7948ffd557-826w4    1/1     Running   0          46h
v2-integration-manager-base-8658598455-jj996                    1/1     Running   0          46h
v2-integration-manager-job-execution-7b756888cd-dn4hd           1/1     Running   0          46h
v2-integration-manager-job-results-processor-785bd99746-n9djz   1/1     Running   0          46h
v2-integration-manager-job-scheduler-75b46d967c-9zlgm           1/1     Running   0          46h
v2-integration-manager-static-content-6745cd599-qcrbs           1/1     Running   0          46h
```

It should include the helm release name prefix