### PR TITLE
CDO-1281 - Merge override ingress & chart ingress routes

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -255,9 +255,9 @@ spec:
               port:
                 number: 8080
           {{- if .Values.ingress.pathVersionPrefix }}
-          path: /{{ .Values.ingress.pathVersionPrefix }}/api/jobs/([^\/]+\/logevents.*)
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api/jobs/[^\/]+\/logevents.*)
           {{- else }}
-          path: /api/jobs/([^\/]+\/logevents.*)
+          path: /api/jobs/[^\/]+/logevents.*
           {{- end }}
           pathType: ImplementationSpecific
         {{- end }}
@@ -438,9 +438,125 @@ spec:
           path: /api/product
           {{- end }}
           pathType: ImplementationSpecific
-        # Expose this when ready
-#        - backend:
-#            serviceName: {{ template "integration-manager.base.fullname" . }}
-#            servicePort: 8080
-#          path: /api/clientdetails
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/resources.*)
+          {{- else }}
+          path: /api/resources
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.job-scheduler.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/resources\/.*\/.*\/schedules.*)
+          {{- else }}
+          path: /api/resources/.*/.*/schedules
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/artifacts.*)
+          {{- else }}
+          path: /api/artifacts
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/artifact-types.*)
+          {{- else }}
+          path: /api/artifact-types
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/integrations.*)
+          {{- else }}
+          path: /api/integrations
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/macrodef.*)
+          {{- else }}
+          path: /api/macrodef
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.base.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/macrosets.*)
+          {{- else }}
+          path: /api/macrosets
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.job-execution.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/integrations\/.*\/jobs.*)
+          {{- else }}
+          path: /api/integrations/.*/jobs
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.job-execution.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(api\/jobconfigs\/.*\/sfdc\/obm)
+          {{- else }}
+          path: /api/jobconfigs/.*/sfdc/obm
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.job-execution.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(notification\/provisioning\/.*)
+          {{- else }}
+          path: /api/notification/provisioning
+          {{- end }}
+          pathType: ImplementationSpecific
+        - backend:
+            service:
+              name: {{ template "integration-manager.job-execution.fullname" . }}
+              port:
+                number: 8080
+          {{- if .Values.ingress.pathVersionPrefix }}
+          path: /{{ .Values.ingress.pathVersionPrefix }}/(notification\/sfdc\/provisioning\/.*)
+          {{- else }}
+          path: /api/notification/sfdc/provisioning
+          {{- end }}
+          pathType: ImplementationSpecific
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,8 +7,8 @@
 imagePullSecrets: []
 serviceAccount:
   annotations: {}
-# Extra values to be added to application.properties
-extraConfig: {}
+extraConfig: |
+  # Extra application.properties
 aggregator:
   image: actian/aggregator-service:2.0.6.294
   # Aggregator Configuration List
@@ -71,7 +71,8 @@ aggregator:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   pdb: {}
     #minAvailable: 1
   replicaCount: 1
@@ -121,7 +122,8 @@ aggregatorProcessor:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   replicaCount: 1
   extraLabels: {}
   podAnnotations: {}
@@ -168,7 +170,8 @@ integrationManagerBase:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   javaOpts: ""
   replicaCount: 1
   extraLabels: {}
@@ -219,7 +222,8 @@ jobExecution:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   replicaCount: 1
   extraLabels: {}
   podAnnotations: {}
@@ -269,7 +273,8 @@ jobLogStreaming:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   replicaCount: 1
   extraLabels: {}
   podAnnotations: {}
@@ -307,7 +312,8 @@ jobResultsProcessor:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   replicaCount: 1
   extraLabels: {}
   podAnnotations: {}
@@ -357,7 +363,8 @@ jobScheduler:
       port: 8080
   pullPolicy: IfNotPresent
   extraInitContainers: []
-  extraConfig: {}
+  extraConfig: |
+    # Extra application.properties
   replicaCount: 1
   extraLabels: {}
   podAnnotations: {}


### PR DESCRIPTION
Adding routes from override ingress into the chart provided ingress

The static content & pervasive ingress resources should remain out of the chart as argo addons

fixes extraConfig helm warnings "coalesce.go:298: warning: cannot overwrite table with non table for integration-manager.integration-manager.integrationManagerBase.extraConfig (map[])";